### PR TITLE
Issues fixes

### DIFF
--- a/SA10M.spec
+++ b/SA10M.spec
@@ -6,7 +6,27 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[('src', 'src'), ('config', 'config')],
-    hiddenimports=['src.database.db_manager', 'src.database.models', 'src.services.log_import_service', 'src.services.cross_check_service', 'src.services.scoring_service', 'src.services.ubn_report_generator', 'src.services.callsign_lookup', 'src.parsers.cabrillo', 'src.core.rules.rules_engine', 'src.core.validation.contact_validator', 'sqlalchemy.dialects.sqlite'],
+    hiddenimports=[
+        'src.database.db_manager',
+        'src.database.models',
+        'src.services.log_import_service',
+        'src.services.cross_check_service',
+        'src.services.scoring_service',
+        'src.services.ubn_report_generator',
+        'src.services.callsign_lookup',
+        'src.parsers.cabrillo',
+        'src.core.rules.rules_engine',
+        'src.core.validation.contact_validator',
+        'sqlalchemy.dialects.sqlite',
+        # openpyxl is imported dynamically inside export methods and is therefore
+        # invisible to PyInstaller's static analysis.  List it and its runtime
+        # dependency (et_xmlfile) explicitly so Excel export works in the bundle.
+        'openpyxl',
+        'openpyxl.styles',
+        'openpyxl.utils',
+        'openpyxl.utils.dataframe',
+        'et_xmlfile',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/SA10M.spec
+++ b/SA10M.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['app_ui.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('src', 'src'), ('config', 'config')],
+    hiddenimports=['src.database.db_manager', 'src.database.models', 'src.services.log_import_service', 'src.services.cross_check_service', 'src.services.scoring_service', 'src.services.ubn_report_generator', 'src.services.callsign_lookup', 'src.parsers.cabrillo', 'src.core.rules.rules_engine', 'src.core.validation.contact_validator', 'sqlalchemy.dialects.sqlite'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='SA10M',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/app_ui.py
+++ b/app_ui.py
@@ -1205,7 +1205,7 @@ class SA10App(tk.Tk):
             self._set_status("Building QSO report…", busy=True)
             try:
                 import openpyxl
-                from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
+                from openpyxl.styles import Font, PatternFill, Alignment
                 from openpyxl.utils import get_column_letter
                 from src.database.db_manager import DatabaseManager
                 from sqlalchemy import text as sql_text

--- a/app_ui.py
+++ b/app_ui.py
@@ -151,8 +151,23 @@ class SA10App(tk.Tk):
         # Redirect stdout/print to the log pane
         sys.stdout = TextRedirector(self._log_text, "stdout")
 
+        # Ensure the database exists and has all tables before first use
+        self._init_database()
+
         # Load contests on startup
         self.after(200, self._refresh_contests)
+
+    # ── Database bootstrap ────────────────────────────────────────────
+
+    def _init_database(self):
+        """Create the database file and all tables if they don't exist yet."""
+        try:
+            from src.database.db_manager import DatabaseManager
+            db = DatabaseManager(self._db_path.get())
+            db.create_all_tables()
+        except Exception as e:
+            # Non-fatal: user can still choose a different DB via File menu
+            self._log(f"Warning: could not initialise database '{self._db_path.get()}': {e}", "warn")
 
     # ── Menu ──────────────────────────────────────────────────────────
 
@@ -815,6 +830,9 @@ class SA10App(tk.Tk):
         tk.Button(btn_row, text="⬇ Export Scores CSV", command=self._export_scores_csv,
                   bg="#6a3d9a", fg="white", font=("Segoe UI", 9, "bold"),
                   relief="flat", padx=10).pack(side="left", padx=(6, 0))
+        tk.Button(btn_row, text="⬇ QSO Report (Excel)", command=self._export_qso_excel,
+                  bg="#b8560a", fg="white", font=("Segoe UI", 9, "bold"),
+                  relief="flat", padx=10).pack(side="left", padx=(6, 0))
 
         # Callsign filter
         self._ldr_filter = tk.StringVar()
@@ -1164,6 +1182,262 @@ class SA10App(tk.Tk):
 
         threading.Thread(target=_run, daemon=True).start()
 
+    def _export_qso_excel(self):
+        """Export a per-participant QSO Excel report with an Observations column."""
+        cid = self._selected_contest_id.get()
+        if not cid:
+            messagebox.showinfo("No contest", "Select an active contest first.")
+            return
+
+        out_path = filedialog.asksaveasfilename(
+            title="Export QSO Report to Excel",
+            defaultextension=".xlsx",
+            filetypes=[("Excel files", "*.xlsx")],
+            initialfile="qso_report.xlsx",
+            initialdir="."
+        )
+        if not out_path:
+            return
+
+        db_path = self._db_path.get()
+
+        def _run():
+            self._set_status("Building QSO report…", busy=True)
+            try:
+                import openpyxl
+                from openpyxl.styles import Font, PatternFill, Alignment, Border, Side
+                from openpyxl.utils import get_column_letter
+                from src.database.db_manager import DatabaseManager
+                from sqlalchemy import text as sql_text
+
+                # Human-readable labels for each validation status
+                STATUS_LABEL = {
+                    "valid":              "VALID",
+                    "duplicate":          "DUPLICATE",
+                    "invalid":            "INVALID",
+                    "invalid_callsign":   "INVALID CALLSIGN",
+                    "invalid_exchange":   "INVALID EXCHANGE",
+                    "out_of_period":      "OUT OF PERIOD",
+                    "invalid_band":       "INVALID BAND",
+                    "invalid_mode":       "INVALID MODE",
+                    "not_in_log":         "NIL (NOT IN LOG)",
+                    "time_mismatch":      "TIME MISMATCH",
+                    "exchange_mismatch":  "EXCHANGE MISMATCH",
+                    "unique_call":        "UNIQUE CALL",
+                }
+
+                # Fill colours per status
+                STATUS_FILL = {
+                    "valid":             PatternFill("solid", fgColor="C6EFCE"),  # light green
+                    "duplicate":         PatternFill("solid", fgColor="FFEB9C"),  # yellow
+                    "not_in_log":        PatternFill("solid", fgColor="FFC7CE"),  # light red
+                    "invalid_callsign":  PatternFill("solid", fgColor="FFC7CE"),
+                    "invalid_exchange":  PatternFill("solid", fgColor="FFC7CE"),
+                    "out_of_period":     PatternFill("solid", fgColor="FFC7CE"),
+                    "invalid_band":      PatternFill("solid", fgColor="FFC7CE"),
+                    "invalid_mode":      PatternFill("solid", fgColor="FFC7CE"),
+                    "invalid":           PatternFill("solid", fgColor="FFC7CE"),
+                    "time_mismatch":     PatternFill("solid", fgColor="FFEB9C"),
+                    "exchange_mismatch": PatternFill("solid", fgColor="FFEB9C"),
+                    "unique_call":       PatternFill("solid", fgColor="DDEBF7"),  # light blue
+                }
+
+                db = DatabaseManager(db_path)
+                with db.get_session() as session:
+                    # ── Summary data ──────────────────────────────────────────────
+                    summary_rows = session.execute(sql_text("""
+                        SELECT l.id AS log_id, l.callsign, l.name,
+                               l.category_operator, l.category_power,
+                               l.category_mode,
+                               COALESCE(s.total_qsos,   0) AS total_qsos,
+                               COALESCE(s.valid_qsos,   0) AS valid_qsos,
+                               COALESCE(s.duplicate_qsos, 0) AS dupe_qsos,
+                               COALESCE(s.not_in_log_qsos, 0) AS nil_qsos,
+                               COALESCE(s.invalid_qsos, 0) AS invalid_qsos,
+                               COALESCE(s.final_score,  0) AS final_score
+                        FROM logs l
+                        LEFT JOIN scores s ON s.log_id = l.id
+                        WHERE l.contest_id = :cid
+                        ORDER BY final_score DESC
+                    """), {"cid": cid}).fetchall()
+
+                    # ── Contact data ──────────────────────────────────────────────
+                    contact_rows = session.execute(sql_text("""
+                        SELECT c.log_id, c.qso_date, c.qso_time, c.band, c.mode,
+                               c.call_sent, c.rst_sent, c.exchange_sent,
+                               c.call_received, c.rst_received, c.exchange_received,
+                               COALESCE(c.points, 0) AS points,
+                               c.validation_status, c.validation_notes
+                        FROM contacts c
+                        JOIN logs l ON c.log_id = l.id
+                        WHERE l.contest_id = :cid
+                        ORDER BY c.log_id, c.qso_date, c.qso_time
+                    """), {"cid": cid}).fetchall()
+
+                # Group contacts by log_id
+                from collections import defaultdict
+                contacts_by_log = defaultdict(list)
+                for row in contact_rows:
+                    contacts_by_log[row.log_id].append(row)
+
+                # ── Build workbook ────────────────────────────────────────────────
+                wb = openpyxl.Workbook()
+
+                # ── Sheet 1: Summary ──────────────────────────────────────────────
+                ws_sum = wb.active
+                ws_sum.title = "Summary"
+
+                hdr_font  = Font(bold=True, color="FFFFFF")
+                hdr_fill  = PatternFill("solid", fgColor="1A3A5C")
+                ctr_align = Alignment(horizontal="center", vertical="center")
+
+                sum_headers = [
+                    "#", "Callsign", "Name", "Category", "Power", "Mode",
+                    "Total QSOs", "Valid QSOs", "Duplicates", "NIL", "Invalid",
+                    "Final Score",
+                ]
+                for col_num, h in enumerate(sum_headers, 1):
+                    cell = ws_sum.cell(1, col_num, h)
+                    cell.font = hdr_font
+                    cell.fill = hdr_fill
+                    cell.alignment = ctr_align
+
+                for idx, r in enumerate(summary_rows, 1):
+                    is_checklog = (r.category_operator or "").upper() == "CHECKLOG"
+                    ws_sum.append([
+                        idx,
+                        r.callsign or "",
+                        r.name or "",
+                        r.category_operator or "",
+                        r.category_power or "",
+                        r.category_mode or "",
+                        r.total_qsos,
+                        r.valid_qsos,
+                        r.dupe_qsos,
+                        r.nil_qsos,
+                        r.invalid_qsos,
+                        0 if is_checklog else r.final_score,
+                    ])
+
+                # Auto-size summary columns
+                for col in ws_sum.columns:
+                    max_len = max((len(str(c.value or "")) for c in col), default=8)
+                    ws_sum.column_dimensions[col[0].column_letter].width = min(max_len + 2, 40)
+
+                # Freeze header row
+                ws_sum.freeze_panes = "A2"
+
+                # ── Per-participant sheets ────────────────────────────────────────
+                qso_headers = [
+                    "#", "Date", "Time", "Band", "Mode",
+                    "Call Sent", "RST Sent", "Exch Sent",
+                    "Call Rcvd", "RST Rcvd", "Exch Rcvd",
+                    "Points", "Observations",
+                ]
+
+                used_titles = set()
+
+                def _safe_sheet_name(callsign: str) -> str:
+                    """Return a valid, unique Excel sheet name (max 31 chars)."""
+                    # Strip characters not allowed in sheet names
+                    for ch in "/\\?*[]:'":
+                        callsign = callsign.replace(ch, "_")
+                    title = callsign[:31]
+                    base, counter = title, 2
+                    while title in used_titles:
+                        suffix = f"_{counter}"
+                        title = base[:31 - len(suffix)] + suffix
+                        counter += 1
+                    used_titles.add(title)
+                    return title
+
+                for r in summary_rows:
+                    log_id   = r.log_id
+                    callsign = r.callsign or f"LOG{log_id}"
+                    contacts = contacts_by_log.get(log_id, [])
+
+                    ws = wb.create_sheet(title=_safe_sheet_name(callsign))
+
+                    # Sheet title row
+                    ws.merge_cells(start_row=1, start_column=1,
+                                   end_row=1,   end_column=len(qso_headers))
+                    title_cell = ws.cell(1, 1, f"{callsign}  —  QSO Report")
+                    title_cell.font = Font(bold=True, size=13, color="FFFFFF")
+                    title_cell.fill = PatternFill("solid", fgColor="1A3A5C")
+                    title_cell.alignment = Alignment(horizontal="left", vertical="center")
+                    ws.row_dimensions[1].height = 22
+
+                    # Column headers (row 2)
+                    for col_num, h in enumerate(qso_headers, 1):
+                        cell = ws.cell(2, col_num, h)
+                        cell.font = hdr_font
+                        cell.fill = hdr_fill
+                        cell.alignment = ctr_align
+
+                    # QSO rows (starting at row 3)
+                    for qso_num, c in enumerate(contacts, 1):
+                        status   = (c.validation_status or "valid").lower()
+                        label    = STATUS_LABEL.get(status, status.upper())
+                        row_fill = STATUS_FILL.get(status)
+                        row_num  = qso_num + 2
+
+                        values = [
+                            qso_num,
+                            c.qso_date or "",
+                            c.qso_time or "",
+                            c.band or "",
+                            c.mode or "",
+                            c.call_sent or "",
+                            c.rst_sent or "",
+                            c.exchange_sent or "",
+                            c.call_received or "",
+                            c.rst_received or "",
+                            c.exchange_received or "",
+                            c.points,
+                            label,
+                        ]
+                        ws.append(values)
+
+                        if row_fill:
+                            for col_num in range(1, len(qso_headers) + 1):
+                                ws.cell(row_num, col_num).fill = row_fill
+
+                    # Auto-size columns
+                    col_widths = [4, 12, 6, 6, 5, 14, 6, 10, 14, 6, 10, 7, 20]
+                    for col_num, width in enumerate(col_widths, 1):
+                        ws.column_dimensions[
+                            get_column_letter(col_num)
+                        ].width = width
+
+                    # Freeze title + header rows
+                    ws.freeze_panes = "A3"
+
+                wb.save(out_path)
+                self._log(
+                    f"QSO report exported: {len(summary_rows)} participants, "
+                    f"{len(contact_rows)} QSOs → {out_path}", "ok"
+                )
+                messagebox.showinfo(
+                    "Export complete",
+                    f"QSO report saved to:\n{out_path}\n\n"
+                    f"{len(summary_rows)} participants / {len(contact_rows)} QSOs"
+                )
+
+            except ImportError:
+                self._log("openpyxl is not installed. Run: pip install openpyxl", "error")
+                messagebox.showerror(
+                    "Missing dependency",
+                    "openpyxl is required for Excel export.\n\nRun: pip install openpyxl")
+            except Exception as e:
+                import traceback
+                self._log(f"QSO report export error: {e}", "error")
+                self._log(traceback.format_exc(), "error")
+                messagebox.showerror("Export error", str(e))
+            finally:
+                self._set_status("Ready")
+
+        threading.Thread(target=_run, daemon=True).start()
+
     def _export_scores_csv(self):
         cid = self._selected_contest_id.get()
         if not cid:
@@ -1227,6 +1501,7 @@ class SA10App(tk.Tk):
         if path:
             self._db_path.set(path)
             self._log(f"Database changed to: {path}", "ok")
+            self._init_database()
             self._refresh_contests()
 
 

--- a/config/contests/sa10m.yaml
+++ b/config/contests/sa10m.yaml
@@ -127,3 +127,12 @@ scoring:
 validation:
   duplicate_window:
     type: band_mode
+  exchange_format:
+    cq_zone:
+      min: 1
+      max: 40
+      description: "CQ Zone (1-40)"
+    rs_rst:
+      ssb_pattern: '^\d{2}$'
+      cw_pattern: '^\d{3}$'
+      description: "Signal report (59 for SSB, 599 for CW)"

--- a/src/core/models/contact.py
+++ b/src/core/models/contact.py
@@ -7,7 +7,7 @@ and provide type safety throughout the application.
 
 from datetime import datetime
 from typing import Optional, Dict, Any
-from pydantic import BaseModel, Field, validator, root_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from enum import Enum
 
 
@@ -65,7 +65,8 @@ class ContactBase(BaseModel):
 
     transmitter_id: Optional[str] = Field(None, description="Transmitter ID for multi-transmitter", max_length=5)
 
-    @validator('mode')
+    @field_validator('mode')
+    @classmethod
     def validate_mode(cls, v):
         """Normalize and validate mode"""
         v = v.upper()
@@ -76,7 +77,8 @@ class ContactBase(BaseModel):
             raise ValueError(f'Invalid mode: {v}')
         return v
 
-    @validator('call_sent', 'call_received')
+    @field_validator('call_sent', 'call_received')
+    @classmethod
     def validate_callsign(cls, v):
         """Basic callsign validation - lenient to allow import of invalid calls"""
         v = v.upper().strip()
@@ -90,7 +92,8 @@ class ContactBase(BaseModel):
             raise ValueError(f'Callsign contains invalid characters: {v}')
         return v
 
-    @validator('frequency')
+    @field_validator('frequency')
+    @classmethod
     def validate_frequency(cls, v):
         """Validate frequency is within amateur bands"""
         # Add basic frequency validation
@@ -98,8 +101,7 @@ class ContactBase(BaseModel):
             raise ValueError('Frequency must be at least 1800 kHz')
         return v
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class Contact(ContactBase):
@@ -130,15 +132,15 @@ class Contact(ContactBase):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ContactCreate(ContactBase):
     """Model for creating a new contact"""
     log_id: int
 
-    @root_validator(skip_on_failure=True)
+    @model_validator(mode='before')
+    @classmethod
     def compute_datetime(cls, values):
         """Compute the combined datetime from date and time"""
         qso_date = values.get('qso_date')
@@ -152,7 +154,8 @@ class ContactCreate(ContactBase):
         return values
 
 
-    @root_validator(skip_on_failure=True)
+    @model_validator(mode='before')
+    @classmethod
     def compute_band(cls, values):
         """Derive band from frequency"""
         freq = values.get('frequency')
@@ -180,8 +183,7 @@ class ContactUpdate(BaseModel):
 
     metadata: Optional[Dict[str, Any]] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 def frequency_to_band(frequency_khz: int) -> str:

--- a/src/core/models/contest_model.py
+++ b/src/core/models/contest_model.py
@@ -6,7 +6,7 @@ Represents contest definitions and metadata.
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ContestBase(BaseModel):
@@ -17,7 +17,8 @@ class ContestBase(BaseModel):
     end_date: datetime = Field(..., description="Contest end date/time")
     rules_file: str = Field(..., description="Path to YAML rules file", max_length=200)
 
-    @validator('slug')
+    @field_validator('slug')
+    @classmethod
     def validate_slug(cls, v):
         """Ensure slug is lowercase and alphanumeric with dashes"""
         v = v.lower().strip()
@@ -25,15 +26,15 @@ class ContestBase(BaseModel):
             raise ValueError('Slug must contain only letters, numbers, dashes, and underscores')
         return v
 
-    @validator('end_date')
-    def validate_end_date(cls, v, values):
+    @field_validator('end_date')
+    @classmethod
+    def validate_end_date(cls, v, info):
         """Ensure end date is after start date"""
-        if 'start_date' in values and v <= values['start_date']:
+        if 'start_date' in info.data and v <= info.data['start_date']:
             raise ValueError('End date must be after start date')
         return v
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class Contest(ContestBase):
@@ -42,8 +43,7 @@ class Contest(ContestBase):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ContestCreate(ContestBase):
@@ -58,8 +58,7 @@ class ContestUpdate(BaseModel):
     end_date: Optional[datetime] = None
     rules_file: Optional[str] = Field(None, max_length=200)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ContestSummary(BaseModel):
@@ -73,6 +72,5 @@ class ContestSummary(BaseModel):
     end_date: datetime
     total_logs: int = 0
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 

--- a/src/core/models/log.py
+++ b/src/core/models/log.py
@@ -6,7 +6,7 @@ Represents the header information from Cabrillo log files.
 
 from datetime import datetime
 from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field, validator, EmailStr
+from pydantic import BaseModel, ConfigDict, Field, field_validator, EmailStr
 
 
 class LogBase(BaseModel):
@@ -59,7 +59,8 @@ class LogBase(BaseModel):
     # Additional metadata
     metadata: Optional[Dict[str, Any]] = Field(None, description="Additional Cabrillo fields")
 
-    @validator('callsign')
+    @field_validator('callsign')
+    @classmethod
     def validate_callsign(cls, v):
         """Validate and normalize callsign"""
         v = v.upper().strip()
@@ -67,14 +68,14 @@ class LogBase(BaseModel):
             raise ValueError('Callsign cannot be empty')
         return v
 
-    @validator('category_operator', 'category_assisted', 'category_band', 'category_mode',
+    @field_validator('category_operator', 'category_assisted', 'category_band', 'category_mode',
                'category_power', 'category_station', 'category_transmitter', 'category_overlay')
+    @classmethod
     def normalize_category(cls, v):
         """Normalize category fields to uppercase"""
         return v.upper() if v else None
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class Log(LogBase):
@@ -96,8 +97,7 @@ class Log(LogBase):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class LogCreate(LogBase):
@@ -124,8 +124,7 @@ class LogUpdate(BaseModel):
     claimed_score: Optional[int] = None
     metadata: Optional[Dict[str, Any]] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class StationInfo(BaseModel):
@@ -151,13 +150,13 @@ class StationInfo(BaseModel):
     state_province: Optional[str] = None
     country: Optional[str] = None
 
-    @validator('operators', pre=True)
+    @field_validator('operators', mode='before')
+    @classmethod
     def parse_operators(cls, v):
         """Parse comma-separated operators into list"""
         if isinstance(v, str):
             return [op.strip() for op in v.split(',') if op.strip()]
         return v
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 

--- a/src/core/models/score.py
+++ b/src/core/models/score.py
@@ -6,7 +6,7 @@ Represents calculated scores and breakdowns.
 
 from datetime import datetime
 from typing import Optional, Dict, List, Any
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ScoreBreakdown(BaseModel):
@@ -43,8 +43,7 @@ class ScoreBreakdown(BaseModel):
     # Validation errors
     validation_errors: Optional[Dict[str, int]] = Field(None, description="Validation error counts")
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class Score(ScoreBreakdown):
@@ -66,8 +65,7 @@ class Score(ScoreBreakdown):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ScoreCreate(BaseModel):
@@ -109,8 +107,7 @@ class ScoreUpdate(BaseModel):
     rank_country: Optional[int] = None
     notes: Optional[str] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ScoreSummary(BaseModel):
@@ -134,8 +131,7 @@ class ScoreSummary(BaseModel):
     # Category for grouping
     category: Optional[str] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class LeaderboardEntry(BaseModel):
@@ -156,6 +152,5 @@ class LeaderboardEntry(BaseModel):
     multipliers: int
     score: int
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 

--- a/src/core/rules/rules_engine.py
+++ b/src/core/rules/rules_engine.py
@@ -329,7 +329,14 @@ class RulesEngine:
         # CQ Zone
         elif mult_type == 'cq_zone':
             zone = contact.exchange_received.get('cq_zone', '')
-            
+            # Must be a valid CQ zone number (1-40); skip non-numeric values like "MG"
+            try:
+                zone_num = int(zone)
+                if not (1 <= zone_num <= 40):
+                    return False
+            except (ValueError, TypeError):
+                return False
+
             if scope == 'per_band_mode':
                 key = self._get_band_mode_key(contact)
                 if key not in self.worked_zones_per_band_mode:
@@ -368,13 +375,20 @@ class RulesEngine:
 
         elif mult_type == 'cq_zone':
             zone = contact.exchange_received.get('cq_zone', '')
-            
+            # Only record valid CQ zone numbers (1-40)
+            try:
+                zone_num = int(zone)
+                if not (1 <= zone_num <= 40):
+                    return
+            except (ValueError, TypeError):
+                return
+
             if scope == 'per_band_mode':
                 key = self._get_band_mode_key(contact)
                 if key not in self.worked_zones_per_band_mode:
                     self.worked_zones_per_band_mode[key] = set()
                 self.worked_zones_per_band_mode[key].add(zone)
-            
+
             # Always update per-band tracking (for backward compatibility)
             band = contact.band
             if band not in self.worked_zones_per_band:

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
     Boolean, Column, DateTime, Enum, Float, ForeignKey,
     Integer, JSON, String, Text, UniqueConstraint, Index
 )
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import relationship
 import enum
 

--- a/src/parsers/cabrillo.py
+++ b/src/parsers/cabrillo.py
@@ -249,7 +249,13 @@ class CabrilloParser:
         
         if s in band_map:
             return band_map[s]
-            
+
+        # Handle float-format frequencies like "28000.00"
+        try:
+            return int(float(freq_str))
+        except (ValueError, TypeError):
+            pass
+
         # Fallback to int conversion which will raise ValueError if invalid
         return int(freq_str)
 

--- a/src/services/cross_check_service.py
+++ b/src/services/cross_check_service.py
@@ -660,17 +660,27 @@ class CrossCheckService:
         reciprocal_map: Dict[tuple, list] = defaultdict(list)
         zone_tally: Dict[tuple, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
 
+        _skipped = 0
         for row in self.session.execute(query, {"contest_id": contest_id}):
             log_callsign, call_received, band, mode, qso_dt_str, exchange_sent = row
             key = (log_callsign, call_received, band, mode)
             try:
                 dt = parse_datetime(qso_dt_str)
                 insort(reciprocal_map[key], dt)
-            except Exception:
-                pass
+            except (ValueError, TypeError) as exc:
+                _skipped += 1
+                print(
+                    f"   [WARN] _build_lookup_caches: skipped unparseable datetime "
+                    f"for {log_callsign} -> {call_received} "
+                    f"band={band} mode={mode} qso_datetime={qso_dt_str!r}: {exc}"
+                )
             if exchange_sent:
                 zone_key = (log_callsign, band, mode)
                 zone_tally[zone_key][str(exchange_sent).strip()] += 1
+
+        if _skipped:
+            print(f"   [WARN] _build_lookup_caches: {_skipped} contact(s) omitted from "
+                  f"reciprocal map due to unparseable datetimes (see warnings above).")
 
         dominant_zone_cache = {
             key: max(counts, key=counts.get)

--- a/src/services/cross_check_service.py
+++ b/src/services/cross_check_service.py
@@ -10,6 +10,8 @@ Uses pure SQL queries to perform fast cross-log validation:
 Based on Phase 4.3 implementation plan.
 """
 
+from bisect import bisect_left, insort
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Tuple, Optional, Set
 from sqlalchemy.orm import Session
@@ -452,6 +454,12 @@ class CrossCheckService:
 
         print(f"   Comparing {len(non_submitted)} non-submitted calls against {len(submitted_calls)} submitted calls...")
 
+        # Pre-load all contact data once so busted-call checks use in-memory
+        # lookups instead of individual SQL queries (major performance win).
+        print("   Pre-loading contact data for fast in-memory lookups...")
+        reciprocal_map, dominant_zone_cache = self._build_lookup_caches(contest_id)
+        _tolerance_sec = self.TIME_TOLERANCE_DAYS * 86400
+
         # Find busted calls by comparing with submitted calls
         # Optimize by filtering by first character and length first
         busted_mapping: Dict[str, List[Tuple[str, float]]] = {}
@@ -563,6 +571,10 @@ class CrossCheckService:
                         best_similarity = 0
                         has_qso = False
 
+                        # Track best distance-1 zone-match candidate (no reciprocal fallback)
+                        best_zone_match_suggestion = None
+                        best_zone_match_similarity = 0
+
                         for suggested_call, similarity in busted_mapping[worked_call]:
                             # Guard: the same suggested_call cannot be used twice for the
                             # same log within 10 minutes (one station can't log us twice)
@@ -572,10 +584,12 @@ class CrossCheckService:
                                 if abs((qso_timestamp - prev_ts).total_seconds()) < 600:
                                     continue
 
+                            edit_distance = Levenshtein.distance(worked_call, suggested_call)
+
                             # Check if suggested station has QSO with logging station at approximately same time
-                            if self._check_reciprocal_exists(
-                                contest_id, suggested_call, row.log_callsign,
-                                qso_timestamp, row.band, row.mode
+                            if self._reciprocal_exists_mem(
+                                reciprocal_map, suggested_call, row.log_callsign,
+                                qso_timestamp, row.band, row.mode, _tolerance_sec
                             ):
                                 # Found a match with reciprocal QSO
                                 best_suggestion = suggested_call
@@ -583,9 +597,23 @@ class CrossCheckService:
                                 has_qso = True
                                 break
 
-                        # Only report as busted if we found a reciprocal QSO
-                        # Otherwise it might just be a station that didn't submit logs
-                        if has_qso and best_suggestion:
+                            # Fallback for distance-1: check if the logged exchange zone
+                            # matches the most common zone sent by the suggested call.
+                            # This catches copies where the other station didn't log us.
+                            if edit_distance == 1 and best_zone_match_suggestion is None:
+                                if self._zone_match_mem(
+                                    dominant_zone_cache, suggested_call,
+                                    row.exchange_received, row.band, row.mode
+                                ):
+                                    best_zone_match_suggestion = suggested_call
+                                    best_zone_match_similarity = similarity
+
+                        # Use zone-match fallback only when no reciprocal was found
+                        if not has_qso and best_zone_match_suggestion:
+                            best_suggestion = best_zone_match_suggestion
+                            best_similarity = best_zone_match_similarity
+
+                        if best_suggestion:
                             used_suggestion[(row.log_id, best_suggestion)] = qso_timestamp
                             entries.append(UBNEntry(
                                 contact_id=row.contact_id,
@@ -603,13 +631,137 @@ class CrossCheckService:
                                 exchange_received=row.exchange_received,
                                 suggested_call=best_suggestion,
                                 similarity_score=best_similarity,
-                                other_station_has_qso=True
+                                other_station_has_qso=has_qso
                             ))
 
                 if (batch_start + batch_size) % 2000 == 0:
                     print(f"   Processed {min(batch_start + batch_size, len(busted_calls_list)):,} / {len(busted_calls_list):,} busted calls...")
 
         return entries
+
+    def _build_lookup_caches(self, contest_id: int):
+        """
+        Pre-load all contact data for the contest into memory so that
+        _find_busted_calls can do O(log n) bisect lookups instead of
+        one SQL round-trip per candidate.
+
+        Returns:
+            reciprocal_map  – {(log_callsign, call_received, band, mode): sorted [datetime, ...]}
+            dominant_zone_cache – {(callsign, band, mode): dominant_exchange_sent_str}
+        """
+        query = text("""
+            SELECT l.callsign, c.call_received, c.band, c.mode,
+                   c.qso_datetime, c.exchange_sent
+            FROM contacts c
+            INNER JOIN logs l ON c.log_id = l.id
+            WHERE l.contest_id = :contest_id
+        """)
+
+        reciprocal_map: Dict[tuple, list] = defaultdict(list)
+        zone_tally: Dict[tuple, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+        for row in self.session.execute(query, {"contest_id": contest_id}):
+            log_callsign, call_received, band, mode, qso_dt_str, exchange_sent = row
+            key = (log_callsign, call_received, band, mode)
+            try:
+                dt = parse_datetime(qso_dt_str)
+                insort(reciprocal_map[key], dt)
+            except Exception:
+                pass
+            if exchange_sent:
+                zone_key = (log_callsign, band, mode)
+                zone_tally[zone_key][str(exchange_sent).strip()] += 1
+
+        dominant_zone_cache = {
+            key: max(counts, key=counts.get)
+            for key, counts in zone_tally.items()
+        }
+        return dict(reciprocal_map), dominant_zone_cache
+
+    @staticmethod
+    def _reciprocal_exists_mem(reciprocal_map: dict, log_callsign: str,
+                                call_received: str, timestamp: datetime,
+                                band: str, mode: str, tolerance_sec: float) -> bool:
+        """In-memory equivalent of _check_reciprocal_exists using bisect."""
+        times = reciprocal_map.get((log_callsign, call_received, band, mode))
+        if not times:
+            return False
+        pos = bisect_left(times, timestamp)
+        for i in (pos - 1, pos):
+            if 0 <= i < len(times):
+                if abs((times[i] - timestamp).total_seconds()) <= tolerance_sec:
+                    return True
+        return False
+
+    @staticmethod
+    def _zone_match_mem(dominant_zone_cache: dict, callsign: str,
+                        logged_exchange: str, band: str, mode: str) -> bool:
+        """In-memory equivalent of _check_zone_match using a pre-built cache."""
+        if not logged_exchange:
+            return False
+        logged_zone = logged_exchange.strip().lstrip('0') or '0'
+        try:
+            zone_num = int(logged_zone)
+            if not (1 <= zone_num <= 40):
+                return False
+        except ValueError:
+            return False
+        dominant = dominant_zone_cache.get((callsign, band, mode))
+        if not dominant:
+            return False
+        station_zone = str(dominant).strip().lstrip('0') or '0'
+        return station_zone == logged_zone
+
+    def _check_zone_match(self, contest_id: int, callsign: str,
+                          logged_exchange: str, band: str, mode: str) -> bool:
+        """
+        Check if the zone logged for a contact matches what the suggested callsign
+        typically sent in this contest.  Used as a distance-1 busted-call fallback
+        when no reciprocal QSO exists.
+
+        Normalises both sides by stripping leading zeros before comparing.
+        Returns True only if there is exactly one dominant zone for the suggested
+        station AND it matches the logged exchange.
+        """
+        if not logged_exchange:
+            return False
+
+        logged_zone = logged_exchange.strip().lstrip('0') or '0'
+
+        # Validate it is a plausible CQ zone number
+        try:
+            zone_num = int(logged_zone)
+            if not (1 <= zone_num <= 40):
+                return False
+        except ValueError:
+            return False
+
+        query = text("""
+            SELECT c.exchange_sent, COUNT(*) as cnt
+            FROM contacts c
+            INNER JOIN logs l ON c.log_id = l.id
+            WHERE l.contest_id = :contest_id
+              AND l.callsign   = :callsign
+              AND c.band       = :band
+              AND c.mode       = :mode
+              AND c.exchange_sent IS NOT NULL
+              AND c.exchange_sent != ''
+            GROUP BY c.exchange_sent
+            ORDER BY cnt DESC
+            LIMIT 1
+        """)
+        row = self.session.execute(query, {
+            "contest_id": contest_id,
+            "callsign": callsign,
+            "band": band,
+            "mode": mode,
+        }).fetchone()
+
+        if not row:
+            return False
+
+        station_zone = str(row[0]).strip().lstrip('0') or '0'
+        return station_zone == logged_zone
 
     def _check_reciprocal_exists(self, contest_id: int, callsign1: str, callsign2: str,
                                   timestamp: datetime, band: str, mode: str) -> bool:

--- a/src/services/scoring_service.py
+++ b/src/services/scoring_service.py
@@ -199,7 +199,8 @@ class ScoringService:
         # Add validation errors if present
         validation_status = getattr(db_contact, 'validation_status_str', 'VALID')
         if validation_status and validation_status.lower() in [
-            'not_in_log', 'busted_call', 'invalid_callsign', 
+            'not_in_log', 'busted_call', 'invalid_callsign',
+            'invalid_exchange', 'invalid',
             'time_mismatch', 'exchange_mismatch'
         ]:
             rules_contact.validation_errors.append(validation_status)
@@ -226,7 +227,8 @@ class ScoringService:
             # Check validation status from cross-check
             validation_status = getattr(db_contact, 'validation_status_str', 'VALID')
             is_invalid = validation_status and validation_status.lower() in [
-                'not_in_log', 'busted_call', 'invalid_callsign', 
+                'not_in_log', 'busted_call', 'invalid_callsign',
+                'invalid_exchange', 'invalid',
                 'time_mismatch', 'exchange_mismatch'
             ]
             

--- a/tests/test_cabrillo_parser.py
+++ b/tests/test_cabrillo_parser.py
@@ -386,6 +386,61 @@ END-OF-LOG:
         assert log.qsos[0].frequency == 28400
         assert 28000 <= log.qsos[0].frequency <= 29000  # 10m band
 
+    def test_float_frequency_format(self, temp_file):
+        """
+        CQ Logs Android and some other loggers write frequency as a float
+        (e.g. "28000.00") instead of an integer.  The parser must handle this
+        without producing a parse error and must return the correct integer kHz.
+
+        Real-world trigger: LU3DSR_20260317_232829_2966.cbr logged 28000.00.
+        """
+        log_text = """START-OF-LOG: 3.0
+CALLSIGN: LU3DSR
+CONTEST: SA10M
+QSO: 28000.00 PH 2025-03-15 1430 LU3DSR 59 13 LU7YE 59 13
+QSO: 28450.50 CW 2025-03-15 1445 LU3DSR 599 13 PY1KJA 599 11
+END-OF-LOG:
+"""
+        temp_file.write(log_text)
+        temp_file.close()
+
+        log = parse_cabrillo_file(temp_file.name)
+
+        # No parse errors — the whole log must be accepted
+        assert log.parse_errors == [], (
+            f"Unexpected parse errors for float-frequency log: {log.parse_errors}"
+        )
+        assert len(log.qsos) == 2
+
+        # Decimal part must be truncated, not rounded
+        assert log.qsos[0].frequency == 28000
+        assert log.qsos[1].frequency == 28450
+
+    def test_float_frequency_edge_cases(self, temp_file):
+        """
+        Additional float-frequency edge cases:
+        - ".0" suffix (no leading digit before decimal)
+        - Large fractional part that still truncates to a valid integer
+        """
+        log_text = """START-OF-LOG: 3.0
+CALLSIGN: W1AW
+CONTEST: SA10M
+QSO: 28000.9 PH 2025-03-15 1200 W1AW 59 5 K1ABC 59 4
+QSO: 28999.0 PH 2025-03-15 1201 W1AW 59 5 K2DEF 59 3
+END-OF-LOG:
+"""
+        temp_file.write(log_text)
+        temp_file.close()
+
+        log = parse_cabrillo_file(temp_file.name)
+
+        assert log.parse_errors == [], (
+            f"Unexpected parse errors: {log.parse_errors}"
+        )
+        assert len(log.qsos) == 2
+        assert log.qsos[0].frequency == 28000   # truncated, not 28001
+        assert log.qsos[1].frequency == 28999
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_cross_check_rules.py
+++ b/tests/test_cross_check_rules.py
@@ -448,6 +448,72 @@ class TestBUSTEDDetection:
         busted_entries = [e for e in ubn_by_log[log_lw5hr.id] if e.ubn_type == UBNType.BUSTED]
         assert len(busted_entries) == 0
 
+    def test_busted_zone_match_fallback_no_reciprocal(self, db_session, test_contest):
+        """
+        Case: Distance-1 busted call detected via zone-match fallback when the
+        other station submitted NO reciprocal QSO.
+
+        Setup:
+          PU4GOL logs 9Y4N (wrong — should be 9Y4I, distance 1)
+          9Y4I submitted a log and sends exchange "9" (zone 9)
+          PU4GOL logged exchange_received "9" from the contact → zone matches
+          9Y4I has NO QSO with PU4GOL in their log → no reciprocal
+
+        Expected:
+          - BUSTED entry for 9Y4N → suggested_call == "9Y4I"
+          - other_station_has_qso is False  ← zone-match fallback branch
+        """
+        log_pu4gol = Log(contest_id=test_contest.id, callsign="PU4GOL", operators="PU4GOL")
+        log_9y4i   = Log(contest_id=test_contest.id, callsign="9Y4I",   operators="9Y4I")
+        db_session.add_all([log_pu4gol, log_9y4i])
+        db_session.commit()
+
+        # PU4GOL heard 9Y4N — 1 char different from 9Y4I — and logged zone "9"
+        contact_pu4gol = Contact(
+            log_id=log_pu4gol.id,
+            qso_datetime=datetime(2025, 3, 8, 15, 0, 0),
+            call_received="9Y4N",   # typo: should be 9Y4I  (distance 1)
+            band="28MHz",
+            mode="SSB",
+            frequency=28500,
+            rst_sent="59", rst_received="59",
+            exchange_sent="11", exchange_received="9",  # zone 9 — matches 9Y4I's sent zone
+            is_valid=True,
+        )
+
+        # 9Y4I's log has ONLY a QSO with someone else — NOT PU4GOL — so no reciprocal
+        contact_9y4i_other = Contact(
+            log_id=log_9y4i.id,
+            qso_datetime=datetime(2025, 3, 8, 15, 1, 0),
+            call_received="LW5HR",  # different station, not PU4GOL
+            band="28MHz",
+            mode="SSB",
+            frequency=28500,
+            rst_sent="59", rst_received="59",
+            exchange_sent="9", exchange_received="13",  # 9Y4I always sends zone 9
+            is_valid=True,
+        )
+        db_session.add_all([contact_pu4gol, contact_9y4i_other])
+        db_session.commit()
+
+        service = CrossCheckService(db_session)
+        ubn_by_log = service.check_all_logs(test_contest.id)
+
+        busted_entries = [e for e in ubn_by_log.get(log_pu4gol.id, [])
+                          if e.ubn_type == UBNType.BUSTED]
+
+        assert len(busted_entries) == 1, (
+            f"Expected 1 BUSTED entry for 9Y4N, got {len(busted_entries)}"
+        )
+        entry = busted_entries[0]
+        assert entry.worked_callsign == "9Y4N"
+        assert entry.suggested_call  == "9Y4I"
+        # Zone-match fallback fires only when no reciprocal QSO was confirmed
+        assert entry.other_station_has_qso is False, (
+            "other_station_has_qso must be False when busted call is detected "
+            "via zone-match fallback (no reciprocal QSO in suggested station's log)"
+        )
+
 
 class TestValidQSO:
     """Test valid QSO detection (no errors)"""

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -27,7 +27,7 @@ class TestRulesLoader:
         
         assert rules.contest.name == "South America 10m Contest"
         assert rules.contest.slug == "sa10m"
-        assert "10" in rules.contest.bands
+        assert "10m" in rules.contest.bands
         assert "SSB" in rules.contest.modes
         assert "CW" in rules.contest.modes
     
@@ -45,7 +45,7 @@ class TestRulesLoader:
         
         assert info['name'] == "South America 10m Contest"
         assert info['slug'] == "sa10m"
-        assert '10' in info['bands']
+        assert '10m' in info['bands']
     
     def test_load_nonexistent_contest(self):
         """Test loading a contest that doesn't exist."""


### PR DESCRIPTION
Validates CQ zone is integer 1–40 before counting/recording as multiplier 
Float-format frequency fallback (28000.00) so CQ Logs Android logs import correctly 
Added 'invalid' / 'invalid_exchange' to invalid-status check lists so bad-exchange QSOs are not scored Zone-match fallback for busted calls without reciprocal
bulk in-memory lookup cache to eliminate per-row SQL queries in busted-call phase